### PR TITLE
Detect when no files were added to the index and skip trying to create a patch in that case.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,8 +74,10 @@ runs:
           popd
         fi
 
+        NO_FORMATTING=
         if git diff --exit-code >/dev/null; then
           echo "No code formatting occurred"
+          NO_FORMATTING=1
         else
           if ${{ inputs.onlyFilesModifiedInPullRequest }}; then
             pwd
@@ -87,9 +89,16 @@ runs:
                   git add -- "$file"
                 fi
             done < <(git diff --diff-filter=d "${BASE_REF}..HEAD" --name-only -z)
+            if git diff --staged --exit-code >/dev/null; then
+              echo "No code formatting occurred"
+              NO_FORMATTING=1
+            fi
           else
             git add -- .
           fi
+        fi
+
+        if test -z "$NO_FORMATTING"; then
           if test -n "${{ inputs.git_user_email }}"; then
             git config --global user.email "${{ inputs.git_user_email }}"
           fi


### PR DESCRIPTION
We correctly detected when no files were autoformatted, but not when some
files were autoformatted, but none in the files from the current PR (and
onlyFilesModifiedInPullRequest=true).

So fix the logic to also detect an empty diff if some files were
autoformatted, but none added to the index.