### PR TITLE
Use the head ref instead of HEAD to compute the list of files. Fixes #6.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,12 +83,13 @@ runs:
             pwd
             ls -la
             BASE_REF=${{ github.event.pull_request.base.sha }}
-            git diff --diff-filter=d "${BASE_REF}..HEAD" --name-only || true
+            HEAD_REF=${{ github.event.pull_request.head.sha }}
+            git diff --diff-filter=d "${BASE_REF}..${HEAD_REF}" --name-only || true
             while IFS= read -r -d $'\0' file; do
                 if test -f "$file"; then
                   git add -- "$file"
                 fi
-            done < <(git diff --diff-filter=d "${BASE_REF}..HEAD" --name-only -z)
+            done < <(git diff --diff-filter=d "${BASE_REF}..${HEAD_REF}" --name-only -z)
             if git diff --staged --exit-code >/dev/null; then
               echo "No code formatting occurred"
               NO_FORMATTING=1


### PR DESCRIPTION
This way we don't take into account files modified in the target branch after the PR was created.

Fixes #6.